### PR TITLE
Fix equal comparison and assignment.

### DIFF
--- a/grammar.lisp
+++ b/grammar.lisp
@@ -59,7 +59,7 @@
        ,@names)))
 
 (define-operator-objects
-  = += -= *= /= %= <<= >>= &= ^= \|=
+  == != = += -= *= /= %= <<= >>= &= ^= \|=
   ++ -- << >>  ^^ \|\| && <= >= < >
   + - * / % & ^ ! \|
   \( \) \[ \] \{ \} \; \. ? \: \,)
@@ -250,7 +250,7 @@
 
 (define-object assignment
       (and (v unary-expression)
-           (v (or := :*= :/= :%= :+= :-= :<= :>= :&= :^= :\|=))
+           (v (or := :*= :/= :%= :+= :<<= :>>= :-= :&= :^= :\|=))
            (v assignment-expression)))
 
 (define-reference expression


### PR DESCRIPTION
Hey Nicolas,

I was playing around with your glsl-toolkit and stumbled upon some errors with simple fixes.
I was unsure if a pull request make sense, the project seems to be under flux, but perhaps this helps.

I tried to parse a bigger file, which failed, but could reduce it to these few test case:

 (parse "int a = (b == 1);")
 (parse "int a = (b != 1);") 
 (parse "int a = (b >= 1);")
 (parse "int a = (b <= 1);")
 (parse "int a = (b >>= 1);")
 (parse "int a = (b <<= 1);")

--

The equal and not-equal binary operators lead to a parse error.

The greater-than and less-than comparisons have been misinterpreted as
an assignment and the shift assignments have been missing.